### PR TITLE
fix(linux): set StartupWMClass to correct value 

### DIFF
--- a/pkgres/icalingua.desktop
+++ b/pkgres/icalingua.desktop
@@ -4,5 +4,7 @@ Exec=icalingua %u
 Icon=icalingua.png
 Name=Icalingua
 Comment=A Linux client for QQ and more
+StartupNotify=true
+StartupWMClass=electron-qq
 Terminal=false
 Type=Application


### PR DESCRIPTION
This will cause the icon to display abnormally after startup (the electron icon is used),
and when it is pinned in the task manager, the electron is actually pinned.
Clicking will start the electron.
(Reproduced in KDE, [2] is a similar problem)

[1]: https://specifications.freedesktop.org/startup-notification-spec/startup-notification-0.1.txt
[2]: https://gitlab.gnome.org/GNOME/gnome-terminal/-/issues/314

Signed-off-by: Coelacanthus <CoelacanthusHex@gmail.com>