### PR TITLE
feat: 允许设置发送消息的按键

### DIFF
--- a/icalingua/src/main/ipc/system.ts
+++ b/icalingua/src/main/ipc/system.ts
@@ -5,6 +5,7 @@ import {getConfig, saveConfigFile} from '../utils/configManager'
 ipcMain.handle('getVersion', app.getVersion)
 ipcMain.handle('getAccount', () => getConfig().account)
 ipcMain.handle('getAria2Settings', () => getConfig().aria2)
+ipcMain.handle('getKeyToSendMessage', () => getConfig().keyToSendMessage)
 ipcMain.handle('getStorePath', () => app.getPath('userData'))
 
 //Solution for 4764a6, 4cf06e, 509310

--- a/icalingua/src/main/utils/configManager.ts
+++ b/icalingua/src/main/utils/configManager.ts
@@ -23,6 +23,7 @@ type AllConfig = {
     privateKey: string
     fetchHistoryOnChatOpen: boolean
     lastUsedStickerType: 'face' | 'remote' | 'stickers' | 'emojis'
+    keyToSendMessage: 'Enter' | 'CtrlEnter' | 'ShiftEnter'
 }
 
 
@@ -80,6 +81,7 @@ const defaultConfig: AllConfig = {
     fetchHistoryOnChatOpen: true,
     //给 @rain15z3 一点面子，而且第一次用的人也没有本地表情
     lastUsedStickerType: 'remote',
+    keyToSendMessage: 'Enter',
 }
 if (!fs.existsSync(configFilePath) && fs.existsSync(oldConfigFilePath)) {
     migrateData()

--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -229,7 +229,7 @@
           }"
                     @input="onChangeInput"
                     @click.right="textctx"
-                    @keydown.enter.exact.prevent=""
+                    @keydown.enter.prevent=""
                 />
 
                 <div class="vac-icon-textarea">
@@ -472,22 +472,60 @@ export default {
             if (this.infiniteState) this.infiniteState.complete()
         },
     },
-    mounted() {
+    async mounted() {
         this.newMessages = []
-
-        window.addEventListener('keydown', (e) => {
-            if (e.key !== 'Enter') return
-            if (e.ctrlKey) {
-                this.message += '\n'
-                setTimeout(() => this.onChangeInput(), 0)
-            }
-            else if (e.shiftKey) {
-                setTimeout(() => this.onChangeInput(), 0)
-            }
-            else {
-                this.sendMessage()
-            }
-        })
+        
+        var keyToSendMessage = await ipc.getKeyToSendMessage()
+    
+        switch (keyToSendMessage) {
+            case 'Enter':
+                window.addEventListener('keydown', (e) => {
+                    if (e.key !== 'Enter') return
+                    if (e.ctrlKey) {
+                        this.message += '\n'
+                        setTimeout(() => this.onChangeInput(), 0)
+                    }
+                    else if (e.shiftKey) {
+                        setTimeout(() => this.onChangeInput(), 0)
+                    }
+                    else {
+                        this.sendMessage()
+                    }
+                })
+                break;
+            case 'CtrlEnter':
+                window.addEventListener('keydown', (e) => {
+                    if (e.key !== 'Enter') return
+                    if (!e.ctrlKey) {
+                        this.message += '\n'
+                        setTimeout(() => this.onChangeInput(), 0)
+                    }
+                    else if (e.shiftKey) {
+                        setTimeout(() => this.onChangeInput(), 0)
+                    }
+                    else {
+                        this.sendMessage()
+                    }
+                })
+                break;
+            case 'ShiftEnter':
+                window.addEventListener('keydown', (e) => {
+                    if (e.key !== 'Enter') return
+                    if (!e.shiftKey) {
+                        this.message += '\n'
+                        setTimeout(() => this.onChangeInput(), 0)
+                    }
+                    else if (e.ctrlKey) {
+                        setTimeout(() => this.onChangeInput(), 0)
+                    }
+                    else {
+                        this.sendMessage()
+                    }
+                })
+                break;
+            default:
+                console.log('qwq')
+        }
 
         window.addEventListener('paste', (event) => {
             console.log(event.clipboardData.files)

--- a/icalingua/src/renderer/utils/ipc.ts
+++ b/icalingua/src/renderer/utils/ipc.ts
@@ -18,6 +18,9 @@ const ipc = {
     async getAria2Settings(): Promise<Aria2Config> {
         return await ipcRenderer.invoke('getAria2Settings')
     },
+    async getKeyToSendMessage(): Promise<'Enter' | 'CtrlEnter' | 'ShiftEnter'> {
+        return await ipcRenderer.invoke('getKeyToSendMessage')
+    },
     async getStorePath(): Promise<string> {
         return await ipcRenderer.invoke('getStorePath')
     },


### PR DESCRIPTION
Now you can set `keyToSendMessage` to `Enter` | `CtrlEnter` | `ShiftEnter` for <kbd>Enter</kbd> | <kbd>Ctrl</kbd>+<kbd>Enter</kbd> | <kbd>Shift</kbd>+<kbd>Enter</kbd>.
The value will be used for sending message and other will be used for wrap.