### PR TITLE
更新 emoji picker 背景色跟随主题，优化滚动条颜色

### DIFF
--- a/icalingua/src/renderer/assets/scrollbar.css
+++ b/icalingua/src/renderer/assets/scrollbar.css
@@ -1,11 +1,6 @@
 ::-webkit-scrollbar {
     width: 6px;
     height: 6px;
-    background-color: #F5F5F5;
-}
-::-webkit-scrollbar-track{
-    -webkit-box-shadow: 0 0 3px rgba(0,0,0,0.3) inset;
-    background-color: #F5F5F5;
 }
 ::-webkit-scrollbar-thumb{
     border-radius: 3px;

--- a/icalingua/src/renderer/components/Stickers.vue
+++ b/icalingua/src/renderer/components/Stickers.vue
@@ -236,8 +236,8 @@ div.head {
 
 <style scoped>
 .emoji-picker {
-  --ep-color-bg: #fff !important;
-  --ep-color-border: #fff !important;
+  --ep-color-bg: auto !important;
+  --ep-color-border: auto !important;
   --ep-color-sbg: #fff !important;
   --ep-color-active: #409eff !important;
   width: 100% !important;


### PR DESCRIPTION
#230 提到 emoji 面板背景颜色不跟随主题，该修改用于修正该问题。
同时，我认为原本的滚动条背景颜色影响观感，所以去除该背景色。

![compare](https://user-images.githubusercontent.com/24190403/134944487-9d8a0a62-d8c7-4765-902b-56cc73dbdddc.png)
